### PR TITLE
Updates to match latest documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1 (August 13, 2021)
+
+* Update config and file permissions to match Deployment Guide
+* Update disk specs to new Reference Architecture recommendations
+* Update default version to 1.8.1
+
 ## 0.1.0 (July 28, 2021)
 
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.1 (August 13, 2021)
+## 0.1.1 (August 20, 2021)
 
 * Update config and file permissions to match Deployment Guide
 * Update disk specs to new Reference Architecture recommendations

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ provider "google-beta" {
 
 module "vault-ent" {
   source               = "hashicorp/vault-ent-starter/gcp"
-  version              = "0.1.0"
+  version              = "0.1.1"
 
   # The shared DNS SAN of the TLS certs being used
   leader_tls_servername  = "vault.server.com"

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -29,7 +29,7 @@ module "user_data" {
   tls_secret_id                     = "terraform_example_module_vault_tls_secret"
   user_supplied_userdata_path       = "/Users/user/Downloads/install_vault.sh.tpl"
   vault_license_name                = "vault.hclic"
-  vault_version                     = "1.8.0"
+  vault_version                     = "1.8.1"
 }
 ```
 

--- a/modules/user_data/templates/install_vault.sh.tpl
+++ b/modules/user_data/templates/install_vault.sh.tpl
@@ -17,9 +17,10 @@ timedatectl set-timezone UTC
 # removing any default installation files from /opt/vault/tls/
 rm -rf /opt/vault/tls/*
 
-touch /opt/vault/tls/{vault-cert.pem,vault-ca.pem,vault-key.pem}
-chown vault:vault /opt/vault/tls/{vault-cert.pem,vault-ca.pem,vault-key.pem}
-chmod 0640 /opt/vault/tls/{vault-cert.pem,vault-ca.pem,vault-key.pem}
+# vault-key.pem should be readable by the vault group only
+touch /opt/vault/tls/vault-key.pem
+chown root:vault /opt/vault/tls/vault-key.pem
+chmod 0640 /opt/vault/tls/vault-key.pem
 
 secret_result=$(gcloud secrets versions access latest --secret=${tls_secret_id})
 
@@ -28,12 +29,15 @@ jq -r .vault_ca <<< "$secret_result" | base64 -d > /opt/vault/tls/vault-ca.pem
 jq -r .vault_pk <<< "$secret_result" | base64 -d > /opt/vault/tls/vault-key.pem
 
 gsutil cp "gs://${gcs_bucket_vault_license}/${vault_license_name}" /opt/vault/vault.hclic
-chown vault:vault /opt/vault/vault.hclic
+# vault.hclic should be readable by the vault group only
+chown root:vault /opt/vault/vault.hclic
 chmod 0640 /opt/vault/vault.hclic
 
 cat << EOF > /etc/vault.d/vault.hcl
 disable_performance_standby = true
 ui = true
+disable_mlock = true
+
 storage "raft" {
   path    = "/opt/vault/data"
   node_id = "$instance_id"
@@ -68,8 +72,10 @@ license_path = "/opt/vault/vault.hclic"
 
 EOF
 
-chown -R vault:vault /etc/vault.d/*
-chmod -R 640 /etc/vault.d/*
+# vault.hcl should be readable by the vault group only
+chown root:root /etc/vault.d
+chown root:vault /etc/vault.d/vault.hcl
+chmod 640 /etc/vault.d/vault.hcl
 
 systemctl enable vault
 systemctl start vault

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "vault_license_filepath" {
 
 variable "vault_version" {
   type        = string
-  default     = "1.8.0"
+  default     = "1.8.1"
   description = "Vault version"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "vm_machine_type" {
 
 variable "vm_disk_size" {
   type        = number
-  default     = 100
+  default     = 500
   description = "VM Disk size"
 }
 


### PR DESCRIPTION
Make some updates to match the latest documentation:
* Update config and file permissions to match Deployment Guide
* Update disk specs to new Reference Architecture recommendations
* Update default version to 1.8.1