### PR TITLE
add variables required for object_storage and iam modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ module "iam" {
   key_ring_id              = module.kms.key_ring_id
   resource_name_prefix     = var.resource_name_prefix
   tls_secret_id            = var.tls_secret_id
+  gcp_project              = var.project_id
 }
 
 module "kms" {
@@ -45,6 +46,7 @@ module "object_storage" {
   resource_name_prefix   = var.resource_name_prefix
   vault_license_filepath = var.vault_license_filepath
   vault_license_name     = var.vault_license_name
+  vault_storage_location = var.storage_location
 }
 
 module "user_data" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -41,6 +41,7 @@ resource "google_kms_key_ring_iam_binding" "vault_iam_kms_binding" {
 resource "google_project_iam_member" "vault_auto_join" {
   member = "serviceAccount:${google_service_account.main.email}"
   role   = google_project_iam_custom_role.autojoin_role.name
+  project = var.gcp_project
 }
 
 resource "google_secret_manager_secret_iam_member" "secret_manager_member" {

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -17,3 +17,9 @@ variable "tls_secret_id" {
   type        = string
   description = "Secret id/name given to the google secrets manager secret"
 }
+
+variable "gcp_project" {
+  type = string
+  description = "GCP project"
+}
+

--- a/modules/object_storage/main.tf
+++ b/modules/object_storage/main.tf
@@ -5,6 +5,7 @@ resource "random_pet" "gcs" {
 resource "google_storage_bucket" "vault_license_bucket" {
   name                        = "${var.resource_name_prefix}-vault-license-${random_pet.gcs.id}"
   uniform_bucket_level_access = true
+  location = var.vault_storage_location
 }
 
 resource "google_storage_bucket_object" "vault_license" {

--- a/modules/object_storage/variables.tf
+++ b/modules/object_storage/variables.tf
@@ -12,3 +12,10 @@ variable "vault_license_name" {
   type        = string
   description = "Filename for Vault license file"
 }
+
+variable "vault_storage_location" {
+  type = string
+  description = "where this bucket goes [us, eu, asia ..]"
+  default = "us"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -141,3 +141,10 @@ variable "vm_disk_type" {
   default     = "pd-ssd"
   description = "VM Disk type. SSD recommended"
 }
+
+variable "storage_location" {
+  type        = string
+  default     = "us"
+  description = "for bucket where license is stored"
+}
+


### PR DESCRIPTION
ran into these errors, and this PR seems to fix it
```
╷
│ Error: Missing required argument
│ 
│   on .terraform/modules/vault-ent/modules/iam/main.tf line 41, in resource "google_project_iam_member" "vault_auto_join":
│   41: resource "google_project_iam_member" "vault_auto_join" {
│ 
│ The argument "project" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│ 
│   on .terraform/modules/vault-ent/modules/object_storage/main.tf line 5, in resource "google_storage_bucket" "vault_license_bucket":
│    5: resource "google_storage_bucket" "vault_license_bucket" {
│ 
│ The argument "location" is required, but no definition was found.
╵
```